### PR TITLE
Update docker-compose.yml location

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,13 +59,13 @@
 - name: Copy plausible docker-compose template.
   ansible.builtin.template:
     src: templates/docker-compose.yml.j2
-    dest: ~/plausible/docker-compose.yml
+    dest: "{{ plausible_volume_base }}/docker-compose.yml"
     mode: '0640'
   become: false
   notify: Restart plausible
 
 - name: Ensure plausible is running.
   community.docker.docker_compose:
-    project_src: ~/plausible/
+    project_src: "{{ plausible_volume_base }}"
     build: false
   become: false


### PR DESCRIPTION
Having the docker-compose.yml in the home directory results in the following, unless you manually create the dir;

```
fatal: [plausible01]: FAILED! => {"changed": false, "checksum": "d31507ad05ba8d996cb95e652691d75b366a0125", "msg": "Destination directory /home/ubuntu/plausible does not exist"}
```

Moving it to the `plausible_volume_base` keeps everything nice and tidy.

Alternatively, if you want to keep it elsewhere, we could have a separate variable (`plausible_dc_dir`) for the compose file location that defaults to `plausible_volume_base`, but is changeable?